### PR TITLE
implemented the Microsoft Graph API to manually upload files to OneDrive

### DIFF
--- a/Source/OneDriveapi/Files_to_OneDrive.py
+++ b/Source/OneDriveapi/Files_to_OneDrive.py
@@ -10,15 +10,15 @@ headers = {
     'Authorization': 'Bearer ' + access_token['access_token']
 }
 
-file_path = '/Users/alexisserrano/Documents/CS222_82/course-project-group-82/Source/images/IMG_1217.png'
+file_path = r'/Users/alexisserrano/Documents/CS222_82/course-project-group-82/Source/images/IMG_1217.png'
 file_name = os.path.basename(file_path)
 with open(file_path, 'rb') as upload:
     media_content = upload.read()
 
 #Upload file to home directory
 response = requests.put(
-    GRAPH_API_ENDPOINT + '/me/drive/items/root:/{file_name}:/content',
-    headers==headers, 
+    GRAPH_API_ENDPOINT + f'/me/drive/items/root:/{file_name}:/content',
+    headers=headers, 
     data=media_content
 )
 


### PR DESCRIPTION
Using the Microsoft Graph API, users can log into Microsoft OneDrive to upload generated files (from speech to text) to their OneDrive directory. This current process only uploads files manually into directory. I plan to make the API into a function call so it can be called within the speech_to_text function. 